### PR TITLE
Send game results to Telegram chat

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -97,8 +97,11 @@ function shuffleArray(array) {
 // Показать текущую карточку
 function showCurrentCard() {
     if (currentCardIndex >= gameCards.length) {
-        // Игра завершена, начинаем заново
+        // Игра завершена, отправляем результат в Telegram
+        sendResultToTelegram();
         currentCardIndex = 0;
+        score = 0;
+        updateScore();
         shuffleArray(gameCards);
     }
 
@@ -226,12 +229,20 @@ function nextCard() {
 // Обновление счета
 function updateScore() {
     scoreElement.textContent = score;
-    
+
     // Анимация увеличения счета
     scoreElement.style.transform = 'scale(1.3)';
     setTimeout(() => {
         scoreElement.style.transform = 'scale(1)';
     }, 300);
+}
+
+// Отправка результата в чат Telegram
+function sendResultToTelegram() {
+    if (window.Telegram && window.Telegram.WebApp) {
+        const resultData = JSON.stringify({ score });
+        window.Telegram.WebApp.sendData(resultData);
+    }
 }
 
 // Показать конфетти


### PR DESCRIPTION
## Summary
- Send score to the Telegram chat that opened the game when all cards have been answered
- Reset score and deck after transmitting the result

## Testing
- `node --check src/scripts/main.js`
- `python -m py_compile web_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b42e699f688322bac083761f6a95c1